### PR TITLE
feat: micronote apis conversion to hold/settle

### DIFF
--- a/commons/config/index.ts
+++ b/commons/config/index.ts
@@ -18,7 +18,6 @@ export default class UlixeeConfig {
   private static cachedConfigLocations: { [cwd_entrypoint: string]: string } = {};
   private static cachedConfigObjects: { [cwd_entrypoint: string]: UlixeeConfig } = {};
 
-  public defaultMinerHost?: string;
   public databoxOutDir?: string;
 
   private get configPath(): string {
@@ -28,7 +27,6 @@ export default class UlixeeConfig {
   constructor(readonly directoryPath: string) {
     if (Fs.existsSync(this.configPath)) {
       const data = JSON.parse(Fs.readFileSync(this.configPath, 'utf8'));
-      this.defaultMinerHost = data.serverHost;
       if (data.databoxOutDir) {
         this.databoxOutDir = Path.isAbsolute(data.databoxOutDir) ? data.databoxOutDir : Path.resolve(this.directoryPath, data.databoxOutDir);
       }
@@ -41,7 +39,6 @@ export default class UlixeeConfig {
 
   private getData(): IUlixeeConfig {
     return {
-      defaultMinerHost: this.defaultMinerHost,
       databoxOutDir: this.databoxOutDir,
     };
   }
@@ -118,7 +115,6 @@ export default class UlixeeConfig {
 }
 
 export interface IUlixeeConfig {
-  defaultMinerHost?: string;
   databoxOutDir?: string
 }
 

--- a/commons/lib/TypeSerializer.ts
+++ b/commons/lib/TypeSerializer.ts
@@ -241,7 +241,8 @@ export default class TypeSerializer {
 
       const startStack = new Error('').stack.slice(8); // "Error: \n" is 8 chars
 
-      const e = new Constructor(message);
+      const e = new Constructor();
+      e.message = message;
       e.name = name;
       Object.assign(e, extras);
       if (stack) {
@@ -255,7 +256,7 @@ export default class TypeSerializer {
 }
 
 export function registerSerializableErrorType(errorConstructor: {
-  new (message?: string): Error;
+  new (...args: any[]): Error;
 }): void {
   TypeSerializer.errorTypes.set(errorConstructor.name, errorConstructor);
 }

--- a/commons/lib/errors.ts
+++ b/commons/lib/errors.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line max-classes-per-file
 class UlixeeError extends Error {
-  constructor(override readonly message, readonly code, protected data?: object) {
+  constructor(override message, public code, public data?: object) {
     // Calling parent constructor of base Error class.
     super(message);
 
@@ -24,7 +24,7 @@ class UlixeeError extends Error {
 }
 
 class APIError extends UlixeeError {
-  constructor(readonly status, json) {
+  constructor(public status, json) {
     super(json.message || 'Unexpected error', json.code, json);
   }
 }

--- a/crypto/lib/Identity.ts
+++ b/crypto/lib/Identity.ts
@@ -139,9 +139,11 @@ export default class Identity {
     const isValid = Ed25519.verify(publicKey, hashedMessage, signature);
     if (isValid === true) return true;
 
-    log.error('Error validating signature', {
-      error: (isValid as Error) ?? new Error('Invalid parameters'),
-    });
+    if (isValid instanceof Error) {
+      log.error('Error validating signature', {
+        error: isValid,
+      });
+    }
     return false;
   }
 }

--- a/specification/common.ts
+++ b/specification/common.ts
@@ -49,3 +49,11 @@ export const micronoteIdValidation = z
 export const centagonTokenValidation = z.bigint().refine(x => x > 0n);
 
 export const micronoteTokenValidation = z.number().int().positive();
+
+export const databoxVersionHashValidation = z
+  .string()
+  .length(62)
+  .regex(
+    /^dbx1[ac-hj-np-z02-9]{58}/,
+    'This is not a Databox versionHash (Bech32 encoded hash starting with "dbx1").',
+  );

--- a/specification/sidechain/GiftCardApis.ts
+++ b/specification/sidechain/GiftCardApis.ts
@@ -42,7 +42,7 @@ export const GiftCardApiSchemas = {
     }),
     result: z.object({
       holdId: z.string().length(32),
-      giftCardBalance: micronoteTokenValidation,
+      remainingBalance: micronoteTokenValidation,
     }),
   },
   'GiftCard.settleHold': {
@@ -57,7 +57,7 @@ export const GiftCardApiSchemas = {
     result: z.object({
       success: z.boolean(),
       microgonsAllowed: micronoteTokenValidation.describe('The microgons settled.'),
-      giftCardBalance: micronoteTokenValidation,
+      remainingBalance: micronoteTokenValidation,
     }),
   },
 };

--- a/specification/sidechain/MicronoteBatchApis.ts
+++ b/specification/sidechain/MicronoteBatchApis.ts
@@ -4,7 +4,7 @@ import { NoteSchema } from '../types/INote';
 import { addressValidation, micronoteTokenValidation } from '../common';
 import { IZodSchemaToApiTypes } from '../utils/IZodApi';
 
-const fundsIdValidation = z.number().int().positive();
+const fundsIdValidation = z.string().length(30);
 
 export const MicronoteBatchApiSchemas = {
   'MicronoteBatch.fund': {
@@ -36,7 +36,7 @@ export const MicronoteBatchApiSchemas = {
       address: addressValidation,
     }),
     result: z.object({
-      fundsId: z.number().int().positive(),
+      fundsId: fundsIdValidation,
       microgonsRemaining: micronoteTokenValidation,
       allowedRecipientAddresses: addressValidation.array().optional(),
     }),

--- a/specification/types/IDataboxFunctionPricing.ts
+++ b/specification/types/IDataboxFunctionPricing.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import { databoxVersionHashValidation } from '../common';
+
+export const DataboxFunctionPricing = z.object({
+  minimum: z.number().int().nonnegative().optional().describe('Minimum price for this step.'),
+  perQuery: z.number().int().nonnegative().describe('Base price per query.'),
+  addOns: z
+    .object({
+      perKb: z
+        .number()
+        .int()
+        .nonnegative()
+        .optional()
+        .describe('Optional add-on price per kilobyte of output data.'),
+    })
+    .optional(),
+  remoteMeta: z
+    .object({
+      host: z.string().describe('The remote host'),
+      databoxVersionHash: databoxVersionHashValidation,
+      functionName: z.string().describe('The remote function name'),
+    })
+    .optional(),
+});
+type IDataboxFunctionPricing = z.infer<typeof DataboxFunctionPricing>;
+
+export default IDataboxFunctionPricing;

--- a/specification/types/IDataboxManifest.ts
+++ b/specification/types/IDataboxManifest.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { addressValidation, identityValidation } from '../common';
-import { databoxVersionHashValidation } from '../databox/DataboxApis';
+import { addressValidation, identityValidation , databoxVersionHashValidation } from '../common';
+import { DataboxFunctionPricing } from './IDataboxFunctionPricing';
 
 const minDate = new Date('2022-01-01').getTime();
 
@@ -25,16 +25,22 @@ export const DataboxManifestSchema = z.object({
   coreVersion: z.string().describe('Version of the Databox Core Runtime'),
   schemaInterface: z.string().optional().describe('The raw typescript schema for this Databox'),
   functionsByName: z.record(
-    z.string().describe('The Function name'),
+    z
+      .string()
+      .regex(/[a-z][A-Za-z0-9]+/)
+      .describe('The Function name'),
     z.object({
       corePlugins: z
         .record(z.string())
         .optional()
         .describe('plugin dependencies required for execution'),
-      pricePerQuery: z.number().int()
-        .nonnegative()
+      prices: DataboxFunctionPricing.array()
+        .min(1)
         .optional()
-        .describe('Price per query if requiring payment'),
+        .describe(
+          'Price details for a function call. This array will have an entry for each function called in this process. ' +
+            'The first entry is the cost of the function packaged in this Databox.',
+        ),
     }),
   ),
   paymentAddress: addressValidation.optional(),

--- a/specification/types/IPayment.ts
+++ b/specification/types/IPayment.ts
@@ -25,10 +25,17 @@ export const MicronoteSchema = z.object({
 });
 
 export const PaymentSchema = z.object({
-  micronote: MicronoteSchema.optional(),
+  micronote: MicronoteSchema.extend({
+    holdAuthorizationCode: z
+      .string()
+      .length(16)
+      .optional()
+      .describe('A hold authorization code granting sub-holds on a micronote.'),
+  }).optional(),
   giftCard: z
     .object({
       id: giftCardIdValidation,
+      sidechainIdentity: identityValidation,
       redemptionKey: giftCardRemptionKeyValidation,
     })
     .optional(),


### PR DESCRIPTION
- Remove defaultMinerHost from config since this makes less sense with autorouting of Miners
- Allow Errors without a "message" as the default argument to be re-constructed by TypeSerializer
- Change Micronote API to allow multiple holds and settles for a single micronote