### PR TITLE
fix: add TransportBridge to net/index.ts and export

### DIFF
--- a/net/index.ts
+++ b/net/index.ts
@@ -2,5 +2,6 @@ import ConnectionToCore from './lib/ConnectionToCore';
 import ConnectionToClient from './lib/ConnectionToClient';
 import WsTransportToCore from './lib/WsTransportToCore';
 import WsTransportToClient from './lib/WsTransportToClient';
+import TransportBridge from './lib/TransportBridge';
 
-export { ConnectionToCore, WsTransportToClient, WsTransportToCore, ConnectionToClient };
+export { ConnectionToCore, WsTransportToClient, WsTransportToCore, ConnectionToClient, TransportBridge };


### PR DESCRIPTION
Fixes importing with ESM via tsx, tsx and ts-node. Fullstack users should import it directly:
import { TransportBridge } from '@ulixee/net';